### PR TITLE
Update spice.tmLanguage.xml to allow asteriks as comment line

### DIFF
--- a/syntaxes/spice.tmLanguage.xml
+++ b/syntaxes/spice.tmLanguage.xml
@@ -95,6 +95,12 @@
           <string>comment.spice</string>
         </dict>
         <dict>
+          <key>match</key>
+          <string>^\s*\*.*$</string>
+          <key>name</key>
+          <string>comment.spice</string>
+        </dict>
+        <dict>
           <key>begin</key>
           <string>(/\*)</string>
           <key>beginCaptures</key>


### PR DESCRIPTION
Traditionally and as stated in the ngspice manual: "The asterisk in the first column indicates that this line is a comment line." To allow for leading white spaces, regex is used here.
Thanks for this nice extension. Maybe my suggestion can be further improved and considered. 
